### PR TITLE
Se eliminan los comentarios en active admin

### DIFF
--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register AdminUser do
-  permit_params :email, :password, :password_confirmation
+  permit_params :email
 
   index do
     selectable_column
@@ -19,8 +19,6 @@ ActiveAdmin.register AdminUser do
   form do |f|
     f.inputs 'Admin Details' do
       f.input :email
-      f.input :password
-      f.input :password_confirmation
     end
     f.actions
   end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register User do
   permit_params :email, :first_name, :last_name,
-                :phone, :password, :password_confirmation, :account_active, :permissions
+                :phone, :account_active, :permissions
 
   member_action :update_account, method: :post
 
@@ -11,8 +11,6 @@ ActiveAdmin.register User do
       f.input :last_name
       f.input :phone
       f.input :permissions, include_blank: false
-      f.input :password
-      f.input :password_confirmation
     end
 
     f.actions
@@ -57,7 +55,6 @@ ActiveAdmin.register User do
       row :created_at
       row :updated_at
     end
-    active_admin_comments
   end
 
   controller do

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -18,12 +18,12 @@ module Api
 
       def render_forbidden_access(exception)
         logger.info(exception) # for logging
-        render json: { error: 'Not Authorized' }, status: :forbidden
+        render json: { error: 'No autorizado' }, status: :forbidden
       end
 
       def render_not_found(exception)
         logger.info(exception) # for logging
-        render json: { error: "Couldn't find the record" }, status: :not_found
+        render json: { error: 'No se encontró el registro' }, status: :not_found
       end
 
       def render_record_invalid(exception)

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -26,11 +26,11 @@ module Api
       end
 
       def failure
-        render json: { errors: ['Login failed.'] }, status: :bad_request
+        render json: { errors: ['Falló el login.'] }, status: :bad_request
       end
 
       def inactive_account_failure
-        render json: { errors: ['Inactive account.'] }, status: :forbidden
+        render json: { errors: ['Cuenta inactiva.'] }, status: :forbidden
       end
 
       private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
   acts_as_token_authentication_handler_for User, fallback_to_devise: false
   rescue_from ActionController::ParameterMissing do
-    render json: { error: 'Parameter Missing' }, status: 400
+    render json: { error: 'Faltan parámetros' }, status: 400
   end
   rescue_from Pundit::NotAuthorizedError do
-    render json: { error: "Doesn't have permissions" }, status: 403
+    render json: { error: 'Faltan permisos' }, status: 403
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -119,7 +119,7 @@ ActiveAdmin.setup do |config|
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'
@@ -129,7 +129,7 @@ ActiveAdmin.setup do |config|
   # config.comments_order = 'created_at ASC'
   #
   # You can disable the menu item for the comments index page:
-  # config.comments_menu = false
+  config.comments_menu = false
   #
   # You can customize the comment menu:
   # config.comments_menu = { parent: 'Admin', priority: 1 }
@@ -138,7 +138,7 @@ ActiveAdmin.setup do |config|
   #
   # Enable and disable Batch Actions
   #
-  config.batch_actions = true
+  config.batch_actions = false
 
   # == Controller Filters
   #

--- a/db/migrate/20160909000402_drop_active_admin_comments.rb
+++ b/db/migrate/20160909000402_drop_active_admin_comments.rb
@@ -1,0 +1,5 @@
+class DropActiveAdminComments < ActiveRecord::Migration
+  def up
+    drop_table :active_admin_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,25 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160907230755) do
+ActiveRecord::Schema.define(version: 20160909000402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "active_admin_comments", force: :cascade do |t|
-    t.string   "namespace"
-    t.text     "body"
-    t.string   "resource_id",   null: false
-    t.string   "resource_type", null: false
-    t.integer  "author_id"
-    t.string   "author_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
-  add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
-  add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
 
   create_table "admin_users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false


### PR DESCRIPTION
Se elimina Comments en el menú de active admin.
Al editar un usuario se elimina el campo password y confirmation_password y los comentarios luego de editado.
Los errores de los controladores se traducen a español·