### PR TITLE
Se modifico el create de image para devolver json

### DIFF
--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -14,7 +14,7 @@ module Api
         authorize @animal
         image = Image.new(file: image_params[:file], animal_id: params[:animal_id])
         if image.save
-          head :created
+          render json: {}, status: :created
         else
           render json: { error: image.errors.as_json }, status: :unprocessable_entity
         end


### PR DESCRIPTION
La comunicacion entre la API y el frontend siempre debe ser entre formato JSON.

Se modifico el render de create image para que devuelva un JSON vacio.