### PR TITLE
Se agrego la raza del animal en el index

### DIFF
--- a/app/views/api/v1/animals/_index.json.jbuilder
+++ b/app/views/api/v1/animals/_index.json.jbuilder
@@ -2,7 +2,7 @@ json.animals @animals do |animal|
   json.name animal.name
   json.id animal.id
   json.chip_num animal.chip_num
-  json.name animal.name
+  json.race animal.race
   json.sex animal.sex_to_s
   json.weight animal.weight
   json.vaccines animal.vaccines


### PR DESCRIPTION
El json del index animales estaba duplicando el atributo `name` y no se devolvia el atributo `race`.

@Isa14 @roviera como verificadores en los test deberian agregar un test que verifque que los atributos que se devuelven son exactamente los que se piden para evitar este tipo de bugs.