### PR TITLE
validar digito verificador de ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'aws-sdk', '~> 2.6.6'
 gem 'axlsx_rails', '~> 0.5.0'
 gem 'axlsx', '~> 2.0.1'
 
+gem 'ci_uy', '~> 0.0.7'
+
 group :development, :test do
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'faker', '~> 1.6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       mimemagic (>= 0.3.0)
     carrierwave-base64 (2.3.1)
       carrierwave (>= 0.8.0, < 0.12.0)
+    ci_uy (0.0.7)
     code_analyzer (0.4.7)
       sexp_processor
     coderay (1.1.1)
@@ -374,6 +375,7 @@ DEPENDENCIES
   axlsx_rails (~> 0.5.0)
   carrierwave (~> 0.11.2)
   carrierwave-base64 (~> 2.3.1)
+  ci_uy (~> 0.0.7)
   database_cleaner (~> 1.4.1)
   delayed_job_active_record (~> 4.0.3)
   devise (~> 3.5.1)

--- a/app/models/adopter.rb
+++ b/app/models/adopter.rb
@@ -21,4 +21,11 @@ class Adopter < ActiveRecord::Base
   validates :first_name, :last_name, :ci, :home_address, presence: true
   validates :first_name, :last_name, length: { maximum: 30 }
   validates :phone, presence: true, format: { with: /\A[0-9]{8}[0-9]?\z/ }
+  validate :correct_ci
+
+  private
+
+  def correct_ci
+    errors.add(:ci, 'La cédula de identidad no es válida.') unless ci =~ /\A[0-9]{7}[0-9]?\z/ && CiUY.validate(ci)
+  end
 end


### PR DESCRIPTION
Se controla el formato de la cédula: que sean solo 7-8 caracteres numéricos.
Si el formato es válido, se controla que el digito verificador sea válido.