### PR TITLE
fix en la llamada a la policy Animal

### DIFF
--- a/app/controllers/api/v1/animals_controller.rb
+++ b/app/controllers/api/v1/animals_controller.rb
@@ -33,10 +33,6 @@ module Api
         end
       end
 
-      def new_animal
-        @species.adoptable? ? @animal = Adoptable.new(adoptable_params) : @animal = Animal.new(animal_params)
-      end
-
       def update
         authorize Animal
         species.adoptable? ? update_params = adoptable_params : update_params = animal_params
@@ -71,6 +67,10 @@ module Api
 
       def set_animal
         @animal = Animal.find(params[:id])
+      end
+
+      def new_animal
+        @species.adoptable? ? @animal = Adoptable.new(adoptable_params) : @animal = Animal.new(animal_params)
       end
 
       def create_report(type_file)

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def create
-        authorize @animal
+        authorize Animal
         event = @animal.events.build(event_params)
         if event.save
           render json: event.as_json(only: [:id]), status: :created
@@ -23,7 +23,7 @@ module Api
       end
 
       def destroy
-        authorize @animal
+        authorize Animal
         @event = @animal.events.find(params[:id])
         @event.destroy
         head :no_content

--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def create
-        authorize @animal
+        authorize Animal
         image = Image.new(file: image_params[:file], animal_id: params[:animal_id], event_id: @event.try(:id))
         if image.save
           render json: {}, status: :created
@@ -22,7 +22,7 @@ module Api
       end
 
       def destroy
-        authorize @animal
+        authorize Animal
         @image = @animal.images.find(params[:id])
         @image.destroy
         head :no_content


### PR DESCRIPTION
Descripcion: Se cambia el método `new_animal` a método privado, estaba como público (incorrecto).

Se cambia la llamada a la Animal Policy en `events_controller.rb` y `images_controller.rb`, ahora se invoca explícitamente a la animal_policy. Antes tenia conflicto, porque cuando un animal es `Adoptable` buscaba la Adoptable Policy por defecto (lo cual era incorrecto).