### PR TITLE
elimina adopciones de adoptantes en lista negra

### DIFF
--- a/app/controllers/api/v1/adopters_controller.rb
+++ b/app/controllers/api/v1/adopters_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class AdoptersController < Api::V1::ApiController
-      before_action :set_adopter, only: [:show, :update, :destroy]
+      before_action :set_adopter, only: [:show, :update, :destroy, :set_as_blacklisted]
       respond_to :json
 
       def index
@@ -23,7 +23,7 @@ module Api
 
       def update
         authorize Adopter
-        if @adopter.update(adopter_params)
+        if @adopter.update(update_adopter_params)
           render json: @adopter.as_json(only: [:id]), status: :ok
         else
           render json: { error: @adopter.errors.as_json }, status: :bad_request
@@ -41,6 +41,12 @@ module Api
         render 'index.json.jbuilder'
       end
 
+      def set_as_blacklisted
+        authorize Adopter
+        @adopter.set_as_blacklisted
+        head :no_content
+      end
+
       private
 
       def set_adopter
@@ -50,6 +56,11 @@ module Api
       def adopter_params
         params.require(:adopter).permit(:first_name, :last_name, :ci, :email,
                                         :phone, :house_description, :blacklisted, :home_address)
+      end
+
+      def update_adopter_params
+        params.require(:adopter).permit(:first_name, :last_name, :email,
+                                        :phone, :house_description, :home_address)
       end
 
       def adopters_search_params

--- a/app/models/adopter.rb
+++ b/app/models/adopter.rb
@@ -26,9 +26,22 @@ class Adopter < ActiveRecord::Base
   validates :phone, presence: true, format: { with: /\A[0-9]{8}[0-9]?\z/ }
   validate :correct_ci
 
+  def set_as_blacklisted
+    set_blacklisted_and_destroy_adoptions unless blacklisted
+  end
+
   private
 
   def correct_ci
     errors.add(:ci, 'La cédula de identidad no es válida.') unless ci =~ /\A[0-9]{7}[0-9]?\z/ && CiUY.validate(ci)
+  end
+
+  def set_blacklisted_and_destroy_adoptions
+    update(blacklisted: true)
+    destroy_adoptions if adoptions.any?
+  end
+
+  def destroy_adoptions
+    adoptions.each(&:destroy)
   end
 end

--- a/app/policies/adopter_policy.rb
+++ b/app/policies/adopter_policy.rb
@@ -17,4 +17,8 @@ class AdopterPolicy
   def destroy?
     @current_user.adopters_edit? || @current_user.super_user?
   end
+
+  def set_as_blacklisted?
+    @current_user.adopters_edit? || @current_user.super_user?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       end
       resources :species, only: [:index]
       get 'adopters/search', to: 'adopters#search'
+      post 'adopters/:id/set_as_blacklisted', to: 'adopters#set_as_blacklisted'
       resources :adopters, except: [:new, :edit] do
         resources :comments, except: [:new, :edit, :update]
       end


### PR DESCRIPTION
Descripcion:
- Nuevo servicio para setear como blacklisted a un adoptante
- Se modifican los parametro del metodo update, para no permitir modificar CI y blacklisted