### PR TITLE
se corrigen algunos bugs

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -40,10 +40,14 @@ module Searchable
       by_castrated(castrated) if castrated.present?
     }
     scope :search_by_admission_date_from, lambda {|admission_date_from|
-      where('admission_date >= ?', admission_date_from) if admission_date_from.present?
+      where('admission_date >= ?', admission_date_from) if admission_date_from.present? &&
+                                                           !(admission_date_from =~ /\A\d{4}-\d{,2}-\d{,2}\z/).nil? &&
+                                                           Date.valid_date?(*admission_date_from.split('-').map(&:to_i))
     }
     scope :search_by_admission_date_to, lambda {|admission_date_to|
-      where('admission_date <= ?', admission_date_to) if admission_date_to.present?
+      where('admission_date <= ?', admission_date_to) if admission_date_to.present? &&
+                                                         !(admission_date_to =~ /\A\d{4}-\d{,2}-\d{,2}\z/).nil? &&
+                                                         Date.valid_date?(*admission_date_to.split('-').map(&:to_i))
     }
     scope :search_by_type, lambda {|type|
       if type == 'Adoptable'

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,7 +22,7 @@ class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }
   validate :correct_date
 
-  default_scope { order(date: :desc) }
+  default_scope { order({ date: :desc }, :name) }
 
   def self.search(params)
     text = '%' + I18n.transliterate(params[:text]) + '%'

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -21,6 +21,8 @@ class Report < ActiveRecord::Base
 
   validates :name, :type_file, :state, :user_id, presence: true
 
+  default_scope { order(created_at: :desc) }
+
   enum type_file:  [:pdf, :excel]
   enum state:  [:processing, :done]
 

--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -13,6 +13,7 @@ class Species < ActiveRecord::Base
   has_many :animals
 
   validates :name, presence: true, allow_nil: false, uniqueness: true
+  validates :name, format: { without: /\s/, message: 'no puede tener espacios' }
 
   def not_deleteable?
     [1, 2, 3].include? id


### PR DESCRIPTION
- En update adopter se quita ci de los parámetros permitidos.
- Se valida que el nombre de la especie no tenga espacios.
- Se ordenan todos los reportes por fecha de creación en orden descendente (los más nuevos arriba).
- Se ordenan los eventos por nombre cuando tienen la misma fecha.
- Sólo se aplica el filtro de fecha de admisión si los parámetros cumplen el formato "AAAA-MM-DD" y corresponden a una fecha válida.
