### PR TITLE
se modifica el método entry_by_week en   estadísticas de adopciones

### DIFF
--- a/app/classes/statistic.rb
+++ b/app/classes/statistic.rb
@@ -5,26 +5,25 @@ class Statistic
       date_aux = @date_iter
       date_start = date_aux
       date_finish_range = date_aux.next_week.yesterday
-      dato = { date_start: date_start, date_finish: date_finish_range }
       adoptions_count = Adoption.search_by_create_date_from(date_start)
                         .search_by_create_date_to(date_finish_range).count
-      dato[:adoptions_count] = adoptions_count
+      dato = { date_start: date_start, date_finish:  date_finish_range, adoptions_count: adoptions_count }
       @datos.push(dato)
       @date_iter = date_start.next_week
     end
     @datos
   end
 
-  def entry_by_week(date_from, date_to)
+  def entry_by_week(date_from, date_to, species_id)
+    species_id = 1 if species_id.nil?
     set_atributes(date_from, date_to)
     while @date_iter < @date_finish
       date_aux = @date_iter
       date_start = date_aux
       date_finish_range = date_aux.next_week.yesterday
-      dato = { date_start: date_start, date_finish:  date_finish_range }
-      entry_count = Animal.search_by_type('Adoptable').search_by_admission_date_from(date_start)
-                    .search_by_admission_date_to(date_finish_range).count
-      dato[:entry_count] = entry_count
+      entry_count = Animal.search_by_species_id(species_id).search_by_admission_date_from(date_start.to_s)
+                    .search_by_admission_date_to(date_finish_range.to_s).count
+      dato = { date_start: date_start, date_finish:  date_finish_range, entry_count: entry_count }
       @datos.push(dato)
       @date_iter = date_start.next_week
     end

--- a/app/controllers/api/v1/statistics_controller.rb
+++ b/app/controllers/api/v1/statistics_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def entry_by_week
-        @datos = Statistic.new.entry_by_week(params[:date_from], params[:date_to])
+        @datos = Statistic.new.entry_by_week(params[:date_from], params[:date_to], params[:species_id])
         render json: { datos: @datos }
       end
     end


### PR DESCRIPTION
Se modifica el método entry_by_week en  estadísticas de adopciones para que filtre por especie y se corrigen errores generados por la modificación de los métodos  search_by_admission_date_from y search_by_admission_date_to 