### PR TITLE
Se valida que el texto de un comentario no sea vacio.

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,5 +21,5 @@ class Comment < ActiveRecord::Base
 
   default_scope { order(created_at: :desc) }
 
-  validates :text, length: { maximum: 500 }
+  validates :text, length: { maximum: 500 }, presence: true
 end

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -175,36 +175,36 @@ es:
   errors:
     format: "%{attribute} %{message}"
     messages:
-      accepted: debe ser aceptado
-      blank: no puede estar en blanco
-      present: debe estar en blanco
-      confirmation: no coincide
-      empty: no puede estar vacío
-      equal_to: debe ser igual a %{count}
-      even: debe ser par
-      exclusion: está reservado
-      greater_than: debe ser mayor que %{count}
-      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
-      inclusion: no está incluido en la lista
-      invalid: no es válido
-      less_than: debe ser menor que %{count}
-      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      accepted: Debe ser aceptado
+      blank: No puede estar en blanco
+      present: Debe estar en blanco
+      confirmation: No coincide
+      empty: No puede estar vacío
+      equal_to: Debe ser igual a %{count}
+      even: Debe ser par
+      exclusion: Está reservado
+      greater_than: Debe ser mayor que %{count}
+      greater_than_or_equal_to: Debe ser mayor que o igual a %{count}
+      inclusion: No está incluido en la lista
+      invalid: No es válido
+      less_than: Debe ser menor que %{count}
+      less_than_or_equal_to: Debe ser menor que o igual a %{count}
       model_invalid: "La validación falló: %{errors}"
-      not_a_number: no es un número
-      not_an_integer: debe ser un entero
-      odd: debe ser impar
-      required: debe existir
-      taken: ya está en uso
+      not_a_number: No es un número
+      not_an_integer: Debe ser un entero
+      odd: Debe ser impar
+      required: Debe existir
+      taken: Ya está en uso
       too_long:
-        one: "es demasiado largo (1 carácter máximo)"
-        other: "es demasiado largo (%{count} caracteres máximo)"
+        one: "Es demasiado largo (1 carácter máximo)"
+        other: "Es demasiado largo (%{count} caracteres máximo)"
       too_short:
-        one: "es demasiado corto (1 carácter mínimo)"
-        other: "es demasiado corto (%{count} caracteres mínimo)"
+        one: "Es demasiado corto (1 carácter mínimo)"
+        other: "Es demasiado corto (%{count} caracteres mínimo)"
       wrong_length:
-        one: "no tiene la longitud correcta (1 carácter exactos)"
-        other: "no tiene la longitud correcta (%{count} caracteres exactos)"
-      other_than: debe ser distinto de %{count}
+        one: "No tiene la longitud correcta (1 carácter exactos)"
+        other: "No tiene la longitud correcta (%{count} caracteres exactos)"
+      other_than: Debe ser distinto de %{count}
     template:
       body: 'Se encontraron problemas con los siguientes campos:'
       header:


### PR DESCRIPTION
Tambien se pone la primer letra de los errores en mayúscula.